### PR TITLE
Cleanup + add support for external bindings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 .vscode/
 build
-
+src/custom_bindings/

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+.vscode/
 build
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,11 @@ add_executable(${PROJECT_NAME}
   src/jmp/setjmp.S
 )
 
+if (EXISTS "src/custom_bindings/custom_bindings.c")
+  message(STATUS "Custom bindings found and added to build")
+  target_sources(${PROJECT_NAME} PRIVATE src/custom_bindings/custom_bindings.c)
+endif()
+
 target_link_libraries(${PROJECT_NAME}
   ffi
   m

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,7 @@ add_executable(${PROJECT_NAME}
   src/primitives.c
   src/net_fixup.c
   src/safeRW.S
+  src/builtin_bindings.c
   src/duktape/duktape.c
   src/jmp/setjmp.S
 )

--- a/src/builtin_bindings.c
+++ b/src/builtin_bindings.c
@@ -1,4 +1,5 @@
 #include "builtin_bindings.h"
+
 #include "custom_bindings.h"
 #include "memfuncs.h"
 #include "primitives.h"
@@ -16,8 +17,8 @@ duk_double_t dummy_get_now(void) /* dummy function to please duktape */
 
 /* weak symbols used if no custom bindings are provided */
 struct native_fn_binding __attribute__((weak)) FUNCTION_BINDINGS[] = {};
-const int __attribute__((weak)) NUM_FUNCTION_BINDINGS = 0;
-void __attribute__((weak)) add_custom_bindings(duk_context *ctx) { }
+const int __attribute__((weak)) NUM_FUNCTION_BINDINGS              = 0;
+void __attribute__((weak)) add_custom_bindings(duk_context* ctx) { }
 
 static duk_ret_t native_print(duk_context* ctx)
 {
@@ -216,22 +217,22 @@ static duk_ret_t duk_dlsym(duk_context* ctx)
   return 1;
 }
 
-void init_builtins(duk_context *ctx)
+void init_builtins(duk_context* ctx)
 {
-	duk_push_c_function(ctx, native_print, DUK_VARARGS);
-	duk_put_global_string(ctx, "print");
-  
-	duk_push_c_function(ctx, duk_dlsym, 3);
-	duk_put_global_string(ctx, "resolveExport");
+  duk_push_c_function(ctx, native_print, DUK_VARARGS);
+  duk_put_global_string(ctx, "print");
 
-	/* add built-ins defined in other files */
-	init_memfuncs(ctx);
-	init_primitives(ctx);
+  duk_push_c_function(ctx, duk_dlsym, 3);
+  duk_put_global_string(ctx, "resolveExport");
+
+  /* add built-ins defined in other files */
+  init_memfuncs(ctx);
+  init_primitives(ctx);
 
   add_custom_bindings(ctx);
   for (int i = 0; i < NUM_FUNCTION_BINDINGS; i++)
   {
-    struct native_fn_binding *binding = &FUNCTION_BINDINGS[i];
+    struct native_fn_binding* binding = &FUNCTION_BINDINGS[i];
     duk_push_c_function(ctx, binding->func, binding->nargs);
     duk_put_global_string(ctx, binding->name);
   }

--- a/src/builtin_bindings.c
+++ b/src/builtin_bindings.c
@@ -1,0 +1,224 @@
+#include "builtin_bindings.h"
+#include "memfuncs.h"
+#include "primitives.h"
+#include "taihen_extra.h"
+
+#include <ffi.h>
+#include <psp2kern/kernel/debug.h>
+
+// BINDINGS
+
+duk_double_t dummy_get_now(void) /* dummy function to please duktape */
+{
+  return 0.0;
+}
+
+static duk_ret_t native_print(duk_context* ctx)
+{
+  duk_push_string(ctx, " ");
+  duk_insert(ctx, 0);
+  duk_join(ctx, duk_get_top(ctx) - 1);
+  ksceKernelPrintf("%s\n", duk_to_string(ctx, -1));
+
+  return 0;
+}
+
+static duk_ret_t duk_dlcall_wrapper(duk_context* ctx)
+{
+  int argn = duk_get_top(ctx);
+  if (argn > 16)
+  {
+    return DUK_RET_EVAL_ERROR;
+  }
+
+  duk_push_this(ctx);
+  duk_push_current_function(ctx);
+  duk_get_prop_string(ctx, -1, "pointer");
+  void* fn = duk_get_pointer(ctx, -1);
+
+  ffi_cif cif;
+
+  ffi_type** args = malloc(argn * sizeof(ffi_type*));
+  void** values   = malloc(argn * sizeof(void*));
+
+  ffi_arg rc;
+
+  uint32_t intvars[16];
+  char* charvars[16];
+  uint8_t* buffers[16] = {0};
+  uint8_t* pointer_vars[16];
+
+  for (int i = 0; i < argn; ++i)
+  {
+    switch (duk_get_type(ctx, i))
+    {
+      case DUK_TYPE_NUMBER:
+        args[i]    = &ffi_type_uint32;
+        intvars[i] = duk_to_uint32(ctx, i);
+        values[i]  = &(intvars[i]);
+        break;
+      case DUK_TYPE_POINTER:
+        args[i]         = &ffi_type_pointer;
+        pointer_vars[i] = duk_to_pointer(ctx, i);
+        values[i]       = &(pointer_vars[i]);
+        break;
+      case DUK_TYPE_STRING:
+        args[i]     = &ffi_type_pointer;
+        charvars[i] = (char*)duk_get_string(ctx, i);
+        values[i]   = &(charvars[i]);
+        break;
+      case DUK_TYPE_OBJECT:
+        if (duk_is_buffer_data(ctx, i))
+        {
+          args[i]    = &ffi_type_pointer;
+          intvars[i] = (uint32_t)duk_get_buffer_data(ctx, i, NULL);
+          values[i]  = &(intvars[i]);
+        }
+        else if (duk_has_prop_string(ctx, i, "_struct"))
+        {
+          // get total buffer size from struct size
+          duk_get_prop_string(ctx, i, "size");
+          uint32_t size = duk_to_uint32(ctx, -1);
+          duk_pop(ctx);
+          // malloc buffer
+          buffers[i] = malloc(size);
+
+          // write structure to buffer
+          duk_push_string(ctx, "writeToMemory");    // [... fields field readFromMemory]
+          duk_push_uint(ctx, (uint32_t)buffers[i]); // [... fields field readFromMemory ptr]
+          duk_call_prop(ctx, i, 1);                 // [... fields field ret]
+          duk_pop(ctx);                             // [... fields field]
+
+          // pass pointer to buffer
+          args[i]    = &ffi_type_pointer;
+          intvars[i] = (uint32_t)buffers[i];
+          values[i]  = &(intvars[i]);
+        }
+        else if (duk_has_prop_string(ctx, i, "_primitive"))
+        {
+          // pass pointer to var
+          args[i] = &ffi_type_pointer;
+
+          // write value to buffer
+          duk_push_string(ctx, "writeToMemory");     // [... fields field readFromMemory]
+          duk_push_uint(ctx, (uint32_t)&intvars[i]); // [... fields field readFromMemory ptr]
+          duk_call_prop(ctx, i, 1);                  // [... fields field ret]
+          duk_pop(ctx);                              // [... fields field]
+
+          pointer_vars[i] = (uint8_t*)&intvars[i];
+          values[i]       = &(pointer_vars[i]);
+        }
+        break;
+      default:
+        free(args);
+        free(values);
+        // free struct buffers
+        for (int i = 0; i < 16; ++i)
+        {
+          if (buffers[i] != NULL)
+          {
+            free(buffers[i]);
+          }
+        }
+        return DUK_RET_TYPE_ERROR;
+        break;
+    }
+  }
+
+  if (ffi_prep_cif(&cif, FFI_DEFAULT_ABI, argn, &ffi_type_sint, args) == FFI_OK)
+  {
+    ffi_call(&cif, fn, &rc, values);
+    duk_push_int(ctx, (int32_t)rc);
+
+    // update Pointer values
+    for (int i = 0; i < argn; ++i)
+    {
+      switch (duk_get_type(ctx, i))
+      {
+        case DUK_TYPE_OBJECT:
+          if (duk_is_buffer_data(ctx, i))
+          {
+            // we already passing a pointer, no need to update it
+          }
+          else if (duk_has_prop_string(ctx, i, "_struct"))
+          {
+            // re-read structure from buffer
+            duk_push_string(ctx, "readFromMemory");   // [... fields field readFromMemory]
+            duk_push_uint(ctx, (uint32_t)buffers[i]); // [... fields field readFromMemory ptr]
+            duk_call_prop(ctx, i, 1);                 // [... fields field ret]
+            duk_pop(ctx);                             // [... fields field]
+          }
+          else if (duk_has_prop_string(ctx, i, "_primitive"))
+          {
+            // pass pointer to var
+            args[i] = &ffi_type_pointer;
+
+            // write value to buffer
+            duk_push_string(ctx, "readFromMemory");    // [... fields field readFromMemory]
+            duk_push_uint(ctx, (uint32_t)&intvars[i]); // [... fields field readFromMemory ptr]
+            duk_call_prop(ctx, i, 1);                  // [... fields field ret]
+            duk_pop(ctx);                              // [... fields field]
+          }
+          break;
+        default:
+          break;
+      }
+    }
+
+    free(args);
+    free(values);
+    // free struct buffers
+    for (int i = 0; i < 16; ++i)
+    {
+      if (buffers[i] != NULL)
+      {
+        free(buffers[i]);
+      }
+    }
+    return 1;
+  }
+
+  free(args);
+  free(values);
+  // free struct buffers
+  for (int i = 0; i < 16; ++i)
+  {
+    if (buffers[i] != NULL)
+    {
+      free(buffers[i]);
+    }
+  }
+
+  return DUK_RET_TYPE_ERROR;
+}
+
+static duk_ret_t duk_dlsym(duk_context* ctx)
+{
+  void* func = NULL;
+
+  const char* name = duk_require_string(ctx, 0);
+  uint32_t libnid  = duk_to_uint32(ctx, 1);
+  uint32_t funcnid = duk_to_uint32(ctx, 2);
+
+  int ret = GetExport(name, libnid, funcnid, &func);
+  if (ret < 0)
+    return duk_reference_error(ctx, "taihen says: 0x%08x", ret);
+
+  duk_idx_t funcIndex = duk_push_c_function(ctx, duk_dlcall_wrapper, DUK_VARARGS);
+  duk_push_pointer(ctx, func);
+  duk_put_prop_string(ctx, funcIndex, "pointer");
+  return 1;
+}
+
+void init_builtins(duk_context *ctx)
+{
+	duk_push_c_function(ctx, native_print, DUK_VARARGS);
+	duk_put_global_string(ctx, "print");
+  
+	duk_push_c_function(ctx, duk_dlsym, 3);
+	duk_put_global_string(ctx, "resolveExport");
+
+	/* add built-ins defined in other files */
+	init_memfuncs(ctx);
+	init_primitives(ctx);
+}

--- a/src/builtin_bindings.c
+++ b/src/builtin_bindings.c
@@ -1,4 +1,5 @@
 #include "builtin_bindings.h"
+#include "custom_bindings.h"
 #include "memfuncs.h"
 #include "primitives.h"
 #include "taihen_extra.h"
@@ -12,6 +13,11 @@ duk_double_t dummy_get_now(void) /* dummy function to please duktape */
 {
   return 0.0;
 }
+
+/* weak symbols used if no custom bindings are provided */
+struct native_fn_binding __attribute__((weak)) FUNCTION_BINDINGS[] = {};
+const int __attribute__((weak)) NUM_FUNCTION_BINDINGS = 0;
+void __attribute__((weak)) add_custom_bindings(duk_context *ctx) { }
 
 static duk_ret_t native_print(duk_context* ctx)
 {
@@ -221,4 +227,12 @@ void init_builtins(duk_context *ctx)
 	/* add built-ins defined in other files */
 	init_memfuncs(ctx);
 	init_primitives(ctx);
+
+  add_custom_bindings(ctx);
+  for (int i = 0; i < NUM_FUNCTION_BINDINGS; i++)
+  {
+    struct native_fn_binding *binding = &FUNCTION_BINDINGS[i];
+    duk_push_c_function(ctx, binding->func, binding->nargs);
+    duk_put_global_string(ctx, binding->name);
+  }
 }

--- a/src/builtin_bindings.h
+++ b/src/builtin_bindings.h
@@ -1,0 +1,8 @@
+#ifndef __BUILTIN_BINDINGS_H__
+#define __BUILTIN_BINDINGS_H__
+
+#include "duktape/duktape.h"
+
+void init_builtins(duk_context *ctx);
+
+#endif

--- a/src/builtin_bindings.h
+++ b/src/builtin_bindings.h
@@ -3,6 +3,6 @@
 
 #include "duktape/duktape.h"
 
-void init_builtins(duk_context *ctx);
+void init_builtins(duk_context* ctx);
 
 #endif

--- a/src/custom_bindings.h
+++ b/src/custom_bindings.h
@@ -1,0 +1,18 @@
+#ifndef __CUSTOM_BINDINGS_H__
+#define __CUSTOM_BINDINGS_H__
+
+#include "duktape/duktape.h"
+
+struct native_fn_binding
+{
+  const char* name;
+  duk_c_function func;
+  duk_idx_t nargs;
+};
+
+extern struct native_fn_binding FUNCTION_BINDINGS[];
+extern const int NUM_FUNCTION_BINDINGS;
+
+extern void add_custom_bindings(duk_context* ctx);
+
+#endif

--- a/src/custom_bindings/custom_bindings_skeleton.c
+++ b/src/custom_bindings/custom_bindings_skeleton.c
@@ -1,0 +1,26 @@
+/**
+ * Custom bindings file skeleton
+ *
+ * Rename this file to "custom_bindings.c" and implement your custom bindings here.
+ */
+#include "../custom_bindings.h"
+
+void add_custom_bindings(duk_context* ctx)
+{
+  duk_push_uint(ctx, 0xCAFECAFE);
+  duk_put_global_string(ctx, "my_native_variable");
+}
+
+static duk_ret_t native_mul(duk_context* ctx)
+{
+  uint32_t input = duk_to_uint32(ctx, 0);
+  duk_push_uint(ctx, input * 2);
+  return 1;
+}
+
+struct native_fn_binding FUNCTION_BINDINGS[] = {
+	/* <JS name>, <native function>, <num of args / DUK_VARARGS> */
+	{"my_native_mul", native_mul, 1},
+};
+
+const int NUM_FUNCTION_BINDINGS = sizeof(FUNCTION_BINDINGS) / sizeof(FUNCTION_BINDINGS[0]);

--- a/src/custom_bindings/custom_bindings_skeleton.c
+++ b/src/custom_bindings/custom_bindings_skeleton.c
@@ -19,8 +19,8 @@ static duk_ret_t native_mul(duk_context* ctx)
 }
 
 struct native_fn_binding FUNCTION_BINDINGS[] = {
-	/* <JS name>, <native function>, <num of args / DUK_VARARGS> */
-	{"my_native_mul", native_mul, 1},
+    /* <JS name>, <native function>, <num of args / DUK_VARARGS> */
+    {"my_native_mul", native_mul, 1},
 };
 
 const int NUM_FUNCTION_BINDINGS = sizeof(FUNCTION_BINDINGS) / sizeof(FUNCTION_BINDINGS[0]);

--- a/src/main.c
+++ b/src/main.c
@@ -125,7 +125,7 @@ int initSafeRW(void)
   if (res < 0)
   {
     int old_res = res;
-    res = GetExport("SceExcpmgr", 0x1496A5B5u, 0x44CE04B8u, &excpmgr_set_memaccesserror_area);
+    res         = GetExport("SceExcpmgr", 0x1496A5B5u, 0x44CE04B8u, &excpmgr_set_memaccesserror_area);
     if (res < 0)
     {
       ksceKernelPrintf("%s: GetExport(Old NID) failed (0x%08X)\n", __func__, old_res);

--- a/src/main.c
+++ b/src/main.c
@@ -1,22 +1,14 @@
+#include "builtin_bindings.h"
 #include "compat.h"
 #include "duktape/duktape.h"
 #include "memfuncs.h"
 #include "net_fixup.h"
-#include "primitives.h"
 #include "safeRW.h"
 #include "taihen_extra.h"
 
-#include <ffi.h>
 #include <psp2kern/kernel/debug.h>
 #include <psp2kern/kernel/modulemgr.h>
 #include <psp2kern/netps.h>
-
-// BINDINGS
-
-duk_double_t dummy_get_now(void)
-{
-  return 0.0;
-}
 
 static void native_fatal(void* udata, const char* msg)
 {
@@ -25,217 +17,12 @@ static void native_fatal(void* udata, const char* msg)
   abort();
 }
 
-static duk_ret_t native_print(duk_context* ctx)
-{
-  duk_push_string(ctx, " ");
-  duk_insert(ctx, 0);
-  duk_join(ctx, duk_get_top(ctx) - 1);
-  ksceKernelPrintf("%s\n", duk_to_string(ctx, -1));
-
-  return 0;
-}
-
-static duk_ret_t duk_dlcall_wrapper(duk_context* ctx)
-{
-  int argn = duk_get_top(ctx);
-  if (argn > 16)
-  {
-    return DUK_RET_EVAL_ERROR;
-  }
-
-  duk_push_this(ctx);
-  duk_push_current_function(ctx);
-  duk_get_prop_string(ctx, -1, "pointer");
-  void* fn = duk_get_pointer(ctx, -1);
-
-  ffi_cif cif;
-
-  ffi_type** args = malloc(argn * sizeof(ffi_type*));
-  void** values   = malloc(argn * sizeof(void*));
-
-  ffi_arg rc;
-
-  uint32_t intvars[16];
-  char* charvars[16];
-  uint8_t* buffers[16] = {0};
-  uint8_t* pointer_vars[16];
-
-  for (int i = 0; i < argn; ++i)
-  {
-    switch (duk_get_type(ctx, i))
-    {
-      case DUK_TYPE_NUMBER:
-        args[i]    = &ffi_type_uint32;
-        intvars[i] = duk_to_uint32(ctx, i);
-        values[i]  = &(intvars[i]);
-        break;
-      case DUK_TYPE_POINTER:
-        args[i]         = &ffi_type_pointer;
-        pointer_vars[i] = duk_to_pointer(ctx, i);
-        values[i]       = &(pointer_vars[i]);
-        break;
-      case DUK_TYPE_STRING:
-        args[i]     = &ffi_type_pointer;
-        charvars[i] = (char*)duk_get_string(ctx, i);
-        values[i]   = &(charvars[i]);
-        break;
-      case DUK_TYPE_OBJECT:
-        if (duk_is_buffer_data(ctx, i))
-        {
-          args[i]    = &ffi_type_pointer;
-          intvars[i] = (uint32_t)duk_get_buffer_data(ctx, i, NULL);
-          values[i]  = &(intvars[i]);
-        }
-        else if (duk_has_prop_string(ctx, i, "_struct"))
-        {
-          // get total buffer size from struct size
-          duk_get_prop_string(ctx, i, "size");
-          uint32_t size = duk_to_uint32(ctx, -1);
-          duk_pop(ctx);
-          // malloc buffer
-          buffers[i] = malloc(size);
-
-          // write structure to buffer
-          duk_push_string(ctx, "writeToMemory");    // [... fields field readFromMemory]
-          duk_push_uint(ctx, (uint32_t)buffers[i]); // [... fields field readFromMemory ptr]
-          duk_call_prop(ctx, i, 1);                 // [... fields field ret]
-          duk_pop(ctx);                             // [... fields field]
-
-          // pass pointer to buffer
-          args[i]    = &ffi_type_pointer;
-          intvars[i] = (uint32_t)buffers[i];
-          values[i]  = &(intvars[i]);
-        }
-        else if (duk_has_prop_string(ctx, i, "_primitive"))
-        {
-          // pass pointer to var
-          args[i] = &ffi_type_pointer;
-
-          // write value to buffer
-          duk_push_string(ctx, "writeToMemory");     // [... fields field readFromMemory]
-          duk_push_uint(ctx, (uint32_t)&intvars[i]); // [... fields field readFromMemory ptr]
-          duk_call_prop(ctx, i, 1);                  // [... fields field ret]
-          duk_pop(ctx);                              // [... fields field]
-
-          pointer_vars[i] = (uint8_t*)&intvars[i];
-          values[i]       = &(pointer_vars[i]);
-        }
-        break;
-      default:
-        free(args);
-        free(values);
-        // free struct buffers
-        for (int i = 0; i < 16; ++i)
-        {
-          if (buffers[i] != NULL)
-          {
-            free(buffers[i]);
-          }
-        }
-        return DUK_RET_TYPE_ERROR;
-        break;
-    }
-  }
-
-  if (ffi_prep_cif(&cif, FFI_DEFAULT_ABI, argn, &ffi_type_sint, args) == FFI_OK)
-  {
-    ffi_call(&cif, fn, &rc, values);
-    duk_push_int(ctx, (int32_t)rc);
-
-    // update Pointer values
-    for (int i = 0; i < argn; ++i)
-    {
-      switch (duk_get_type(ctx, i))
-      {
-        case DUK_TYPE_OBJECT:
-          if (duk_is_buffer_data(ctx, i))
-          {
-            // we already passing a pointer, no need to update it
-          }
-          else if (duk_has_prop_string(ctx, i, "_struct"))
-          {
-            // re-read structure from buffer
-            duk_push_string(ctx, "readFromMemory");   // [... fields field readFromMemory]
-            duk_push_uint(ctx, (uint32_t)buffers[i]); // [... fields field readFromMemory ptr]
-            duk_call_prop(ctx, i, 1);                 // [... fields field ret]
-            duk_pop(ctx);                             // [... fields field]
-          }
-          else if (duk_has_prop_string(ctx, i, "_primitive"))
-          {
-            // pass pointer to var
-            args[i] = &ffi_type_pointer;
-
-            // write value to buffer
-            duk_push_string(ctx, "readFromMemory");    // [... fields field readFromMemory]
-            duk_push_uint(ctx, (uint32_t)&intvars[i]); // [... fields field readFromMemory ptr]
-            duk_call_prop(ctx, i, 1);                  // [... fields field ret]
-            duk_pop(ctx);                              // [... fields field]
-          }
-          break;
-        default:
-          break;
-      }
-    }
-
-    free(args);
-    free(values);
-    // free struct buffers
-    for (int i = 0; i < 16; ++i)
-    {
-      if (buffers[i] != NULL)
-      {
-        free(buffers[i]);
-      }
-    }
-    return 1;
-  }
-
-  free(args);
-  free(values);
-  // free struct buffers
-  for (int i = 0; i < 16; ++i)
-  {
-    if (buffers[i] != NULL)
-    {
-      free(buffers[i]);
-    }
-  }
-
-  return DUK_RET_TYPE_ERROR;
-}
-
-static duk_ret_t duk_dlsym(duk_context* ctx)
-{
-  void* func = NULL;
-
-  const char* name = duk_require_string(ctx, 0);
-  uint32_t libnid  = duk_to_uint32(ctx, 1);
-  uint32_t funcnid = duk_to_uint32(ctx, 2);
-
-  int ret = GetExport(name, libnid, funcnid, &func);
-  if (ret < 0)
-    return duk_reference_error(ctx, "taihen says: 0x%08x", ret);
-
-  duk_idx_t funcIndex = duk_push_c_function(ctx, duk_dlcall_wrapper, DUK_VARARGS);
-  duk_push_pointer(ctx, func);
-  duk_put_prop_string(ctx, funcIndex, "pointer");
-  return 1;
-}
-
 static void do_duk(char* buf, uint32_t len)
 {
   duk_context* ctx = duk_create_heap(NULL, NULL, NULL, NULL, native_fatal);
 
   // globals
-  // TODO: move to init funcs?
-  duk_push_c_function(ctx, native_print, DUK_VARARGS);
-  duk_put_global_string(ctx, "print");
-
-  duk_push_c_function(ctx, duk_dlsym, 3);
-  duk_put_global_string(ctx, "resolveExport");
-
-  init_memfuncs(ctx);
-  init_primitives(ctx);
+  init_builtins(ctx);
 
   // eval
 

--- a/src/memfuncs.c
+++ b/src/memfuncs.c
@@ -92,32 +92,6 @@ static duk_ret_t duk_writebuffer(duk_context* ctx)
   return 0;
 }
 
-int init_memfuncs_module(void)
-{
-  int (*excpmgr_set_memaccesserror_area)(void* start, void* end);
-
-  int res = GetExport("SceExcpmgr", 0x4CA0FDD5u, 0xC45C0D3Du, &excpmgr_set_memaccesserror_area);
-  if (res < 0)
-  {
-    ksceKernelPrintf("%s: GetExport(Old NID) failed (0x%08X)\n", __func__, res);
-    res = GetExport("SceExcpmgr", 0x1496A5B5u, 0x44CE04B8u, &excpmgr_set_memaccesserror_area);
-    if (res < 0)
-    {
-      ksceKernelPrintf("%s: GetExport(New NID) failed (0x%08X)\n", __func__, res);
-      return res;
-    }
-  }
-
-  res = excpmgr_set_memaccesserror_area(&_safeRWRegionStart, &_safeRWRegionEnd);
-  if (res < 0)
-  {
-    ksceKernelPrintf("%s: excpmgr_set_memaccesserror_area() failed (0x%08X)\n", __func__, res);
-    return res;
-  }
-
-  return 0;
-}
-
 void init_memfuncs(duk_context* ctx)
 {
   duk_push_c_function(ctx, duk_read32, 1);

--- a/src/net_fixup.c
+++ b/src/net_fixup.c
@@ -82,8 +82,8 @@ int fixup_netrecv_bug(void)
     return res;
   }
 
-  text_base   = (SceUInt32)netps_info.segments[0].vaddr;
-  text_size   = netps_info.segments[0].memsz;
+  text_base = (SceUInt32)netps_info.segments[0].vaddr;
+  text_size = netps_info.segments[0].memsz;
   /* no newline for now - we'll try to print pattern offset on same line */
   ksceKernelPrintf("SceNetPs seg0 @ 0x%08X size 0x%X", text_base, text_size);
 

--- a/src/primitives.c
+++ b/src/primitives.c
@@ -844,7 +844,7 @@ duk_ret_t duk_struct_get(duk_context* ctx)
 
     if (strcmp(nameset, name) == 0)
     {
-        return 1; // field is on stack
+      return 1; // field is on stack
     }
 
     duk_pop(ctx); // [... fields]


### PR DESCRIPTION
* Add `.vscode` to gitignore
* Cleanup dead code, reduce log amount and improve log messages in `net_fixup.c`
* Move SafeRW module initialization to `main.c`
* Move built-in/bindings defined in `main.c` to a dedicated file
* Perform injection of bindings in duktape context from a single function
* Add simple mechanism to define additional native bindings
  * Includes an example implementation